### PR TITLE
Use C locale

### DIFF
--- a/generator/src/main/bash/mkdiff.sh
+++ b/generator/src/main/bash/mkdiff.sh
@@ -96,6 +96,8 @@ function usage {
    echo "-h this help"
 }
 
+LC_ALL=C
+
 TMP_FILES=
 NEW_WAR=
 OLD_WAR=


### PR DESCRIPTION
Some linux installations are in french, so diff will output sentences in french.
Setting the locale to C will output sentences in english.
